### PR TITLE
Add docs as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy
+[submodule "content/en/docs"]
+	path = content/en/docs
+	url = https://github.com/cdevents/spec

--- a/config.toml
+++ b/config.toml
@@ -119,12 +119,13 @@ version = "0.0"
 url_latest_version = "https://cdevents.dev/docs"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/cdevents/cdevents.dev"
+github_repo = "https://github.com/cdevents/spec"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 github_project_repo = "https://github.com/cdevents/spec"
 
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""
+path_base_for_github_subdir = "content/en/docs/"
 
 # Uncomment this if you have a newer GitHub repo with "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -6,8 +6,8 @@ linkTitle = "cdevents.dev Homepage"
 
 {{< blocks/cover title="CDEvents" subtitle="A common specification for Continuous Delivery events" image_anchor="top" color="primary" height="min">}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-dark mr-3 mb-4" href="https://github.com/cdevents/spec">
-		Documentation <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+	<a class="btn btn-lg btn-dark mr-3 mb-4" href="docs">
+		Get Started <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-light mr-3 mb-4" href="https://github.com/cdevents">
 		GitHub <i class="fab fa-github ml-2 "></i>


### PR DESCRIPTION
Add the spec repo as a submodule.
Configure the site to have working docs and edit links.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>