### PR TITLE
Serve schema files through static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ resources/
 node_modules/
 package-lock.json
 .hugo_build.lock
+# Local Netlify folder
+.netlify

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 .PHONY: serve
 serve:
 	echo "Local development"
-	cd themes/docsy && git submodule update -f --init
-	cp content/en/docs/images/* static/images/
-	sed -i -e 's/\(images\/[a-zA-Z\-]*\.svg\)/\/\1/g' content/en/docs/*.md
+	./scripts/build-static.sh
 	hugo server \
 	--baseURL $(URL) \
 	--buildDrafts \
@@ -14,14 +12,10 @@ serve:
 
 .PHONY: production-build
 production-build:
-	cd themes/docsy && git submodule update -f --init
-	cp content/en/docs/images/* static/images/
-	sed -i -e 's/\(images\/[a-zA-Z\-]*\.svg\)/\/\1/g' content/en/docs/*.md
+	./scripts/build-static.sh
 	hugo --baseURL $(URL)
 
 .PHONY: preview-build
 preview-build:
-	cd themes/docsy && git submodule update -f --init
-	cp content/en/docs/images/* static/images/
-	sed -i -e 's/\(images\/[a-zA-Z\-]*\.svg\)/\/\1/g' content/en/docs/*.md
+	./scripts/build-static.sh
 	hugo --baseURL $(DEPLOY_PRIME_URL)

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Build static content from the spec repo
+set -exo pipefail
+
+BASE_DIR="$( cd "$( dirname "$0" )/.." >/dev/null 2>&1 && pwd )"
+STATIC_DIR="${BASE_DIR}/static"
+DOCS_DIR="${BASE_DIR}/content/en/docs"
+
+# Serve static images
+cp ${DOCS_DIR}/images/* ${STATIC_DIR}/images/
+sed -i -e 's/\(images\/[a-zA-Z\-]*\.svg\)/\/\1/g' ${DOCS_DIR}/*.md
+
+# Serve versioned schemas
+cd ${DOCS_DIR}
+ORIGINAL_REVISION=$(git rev-parse HEAD)
+for tag in $(git tag); do
+    # Get the version by trimming the "v"
+    version=$(printf $tag | sed 's/^v//g')
+    TARGET_SCHEMA_FOLDER="${STATIC_DIR}/${version}/schema"
+    # Create the folder if it doesn't exists yet
+    mkdir -p ${TARGET_SCHEMA_FOLDER} || true
+
+    git checkout "${tag}"
+    for schema in $(ls schemas/*json); do
+        # Extract the schema name from the schema id itself
+        TARGET_SCHEMA=$(awk -F'/' '/"\$id"/{ print $6 }' $schema | sed -e 's/",//g')
+        # Copy the file to static with the new name
+        cp ${schema} ${TARGET_SCHEMA_FOLDER}/${TARGET_SCHEMA}
+    done
+done
+git checkout ${ORIGINAL_REVISION}


### PR DESCRIPTION
Add a script that prepares static content before the site build.
The script handles static images (which used to be done directly
in the makefile) and it also copies schema files to the right
location in static for each version declared in the script.

Fixes #11

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>