### PR TITLE
Restore serving json schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ serve:
 
 .PHONY: production-build
 production-build:
-#	./scripts/build-static.sh
+	./scripts/build-static.sh
 	hugo --baseURL $(URL)
 
 .PHONY: preview-build
 preview-build:
-#	./scripts/build-static.sh
+	./scripts/build-static.sh
 	hugo --baseURL $(DEPLOY_PRIME_URL)

--- a/config.toml
+++ b/config.toml
@@ -112,7 +112,7 @@ archived_version = false
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the
 # current doc set.
-version = "v0.1.1"
+version = "v0.1.2"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
@@ -125,9 +125,9 @@ url_latest_version = "https://cdevents.dev/docs"
   version = "latest"
   url = "https://cdevents.dev/docs"
 
-#[[params.versions]]
-#  version = "v0.1.1"
-#  url = "https://github.com/cdevents/spec/tree/v0.1.1"
+[[params.versions]]
+ version = "v0.1.1"
+ url = "https://github.com/cdevents/spec/tree/v0.1.1/spec.md"
 
 [[params.versions]]
   version = "v0.1.0"

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -5,11 +5,13 @@ set -exo pipefail
 
 BASE_DIR="$( cd "$( dirname "$0" )/.." >/dev/null 2>&1 && pwd )"
 STATIC_DIR="${BASE_DIR}/static"
-DOCS_DIR="${BASE_DIR}/content/en/docs"
+DOCS_DIR="$(mktemp -d)"
+
+# Clone the spec repo to pull the schemas
+git clone https://github.com/cdevents/spec ${DOCS_DIR}
 
 # Serve versioned schemas
-cd ${DOCS_DIR}
-ORIGINAL_REVISION=$(git rev-parse HEAD)
+cd "${DOCS_DIR}"
 for tag in $(git tag); do
     # Get the version by trimming the "v"
     version=$(printf $tag | sed 's/^v//g')
@@ -25,8 +27,3 @@ for tag in $(git tag); do
         cp ${schema} ${TARGET_SCHEMA_FOLDER}/${TARGET_SCHEMA}
     done
 done
-git checkout ${ORIGINAL_REVISION}
-
-# Serve static images
-cp ${DOCS_DIR}/images/* ${STATIC_DIR}/images/
-sed -i -e 's/\(images\/[a-zA-Z\-]*\.svg\)/\/\1/g' ${DOCS_DIR}/*.md


### PR DESCRIPTION
Without the submodule, do a git clone to restore serving the schemas through the website.

Update latest version to v0.1.2.

#Fixes: spec/#110