### PR TITLE
Update out of date information on the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ resources/
 node_modules/
 package-lock.json
 .hugo_build.lock
+
 # Local Netlify folder
 .netlify
 .DS_Store
+
+# Downstream files
+static/0.1.0/
+static/0.1.1/
+static/0.1.2/

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -55,3 +55,11 @@
 .alt-link {
     color: $alt-link;
 }
+
+.very-opaque-image {
+    opacity: 0.8;
+}
+
+.slightly-opaque-image {
+    opacity: 0.4;
+}

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -110,13 +110,21 @@ CDEvents is an incubated project at the <a href="https://cd.foundation/projects"
 	{{< card header="Source Code Control Events" >}}
 	Represent events associated with the management of source code assets
 	{{< /card >}}
-	{{< card header="Continuous Integration Pipelines Events" >}}
+	{{< card header="Continuous Integration Events" >}}
 	Represent events related to building, testing, packaging, and releasing software artifacts
 	{{< /card >}}
 {{< /cardpane >}}
 {{< cardpane >}}
-	{{< card header="Continuous Deployment Pipelines Events" >}}
+	{{< card header="Testing Events" >}}
+	Represent events associated with Testing activities
+	{{< /card >}}
+	{{< card header="Continuous Deployment Events" >}}
 	Represent events related to environments where the artifacts produced by the integration pipelines are intended to run
+	{{< /card >}}
+{{< /cardpane >}}
+{{< cardpane >}}
+	{{< card header="Continuous Operations Events" >}}
+	Represent events associated with Continuous Operations activities, such as incidents and their resolution
 	{{< /card >}}
 	{{< card header="Core Events" >}}
 	Represent shared abstractions such as Task Runs and Pipeline Runs
@@ -124,7 +132,7 @@ CDEvents is an incubated project at the <a href="https://cd.foundation/projects"
 {{< /cardpane >}}
 
 <p>
-	There is interest in implementing in many of your favorite CI/CD tools, including ArgoCD, Flux, Jenkins, Jenkins-X, Keptn, Knative, Ortelius, Shipwright, Spinnaker, Tekton. Some of them have started proof-of-concept implementations with CDEvents.
+	CDEvents is implemented or being integrated by many of your favorite SDLC tools, including Argo, Flux, Guac, Harbor, Jenkins, Keptn, Spinnaker, Tekton, Testkube, Tracetest and more.
 </p>
 <br/><br/>
 <div class="mx-auto">
@@ -134,6 +142,25 @@ CDEvents is an incubated project at the <a href="https://cd.foundation/projects"
 </div>
 {{< /blocks/cdelead >}}
 
+{{< blocks/lead title="CDF" color="light">}}
+CDEvents is implemented or being integrated by many of your favorite SDLC tools, including Argo, Flux, Guac, Harbor, Jenkins, Keptn, Spinnaker, Tekton, Testkube, Tracetest and more.</br></br>
+
+<a href="https://www.jenkins.io" aria-label="Jenkins"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/jenkins/stacked/color/jenkins-stacked-color.svg" width="15%" alt="Jenkins Logo"/></a>&nbsp;&nbsp;
+<a href="https://testkube.io" aria-label="testkube"><img src="https://raw.githubusercontent.com/kubeshop/testkube/develop/assets/testkube-color-dark.png" width="20%" alt="Testkube Logo"/></a>
+</br></br>
+<a href="https://spinnaker.io" aria-label="Spinnaker"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/spinnaker/stacked/color/spinnaker-stacked-color.svg" width="15%" alt="Spinnaker Logo" class="very-opaque-image"/></a>&nbsp;&nbsp;
+<a href="https://tekton.dev" aria-label="Tekton"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/tekton/stacked/color/tekton-stacked-color.svg" width="15%" alt="Tekton Logo" class="very-opaque-image"/></a>
+</br></br>
+<a href="https://argoproj.github.io" aria-label="Argo"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/argo/stacked/color/argo-stacked-color.svg" width="10%" alt="Argo Logo" class="slightly-opaque-image"/></a>&nbsp;&nbsp;
+<a href="https://flux.io" aria-label="Flux"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/stacked/color/flux-stacked-color.svg" width="10%" alt="Flux Logo" class="slightly-opaque-image"/></a>&nbsp;&nbsp;
+<a href="https://goharbor.io" aria-label="Harbor"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/harbor/stacked/color/harbor-stacked-color.svg" width="10%" alt="Harbor Logo" class="slightly-opaque-image"/></a>&nbsp;&nbsp;
+<a href="https://guac.sh" aria-label="Guac"><img src="https://user-images.githubusercontent.com/3060102/204297133-9bf702c6-b4e2-46df-a029-42b5060b19a4.png" width="10%" alt="Guac Logo" class="slightly-opaque-image"/></a>&nbsp;&nbsp;
+<a href="https://keptn.sh" aria-label="Keptn"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/keptn/stacked/color/keptn-stacked-color.svg" width="10%" alt="Keptn Logo" class="slightly-opaque-image"/></a>&nbsp;&nbsp;
+<a href="https://tracetest.io" aria-label="tracetest"><img src="https://github.com/kubeshop/tracetest/raw/main/assets/tracetest-logo-color-w-black-text.svg" width="20%" alt="Tracetest Logo" class="slightly-opaque-image"/></a>
+
+{{< /blocks/lead >}}
+
+
 {{% blocks/section color="secondary" %}}
 
 {{% blocks/feature icon="fa-users" title="Community" %}}
@@ -141,13 +168,13 @@ The project is developed and maintained by the <a href="https://github.com/cdfou
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fa-cogs" title="Demos" %}}
-Our first <a href="https://github.com/cdfoundation/sig-events/tree/main/poc#cdf-sig-events-protocol-proof-of-concept">proof of concept</a> includes CDEvents in <a href="https://tekton.dev">Tekton</a> and <a href="https://keptn.sh">Keptn</a>. 
+Our <a href="https://github.com/cdfoundation/sig-events/tree/main/poc#cdf-sig-events-protocol-proof-of-concept">proof of concepts</a> includes CDEvents in <a href="https://tekton.dev">Tekton</a> , <a href="https://spinnaker.io/">Spinnaker</a> and <a href="https://keptn.sh">Keptn</a>. 
 We are building the next PoC to produce DevOps metrics through CDEvents.
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fa-spinner" title="In Progress" %}}
 Our specification work is driven by interoperability use cases.
-Our first <a href="https://github.com/cdevents/spec/releases/tag/v0.1.0">release v0.1.0</a> includes a <a href="https://github.com/cdevents/sdk-go/releases/tag/v0.1.0">Go SDK</a>.
+Our latest <a href="https://github.com/cdevents/spec/releases/tag/v0.3.0">release v0.3.0</a> includes a <a href="https://github.com/cdevents/sdk-go/releases/tag/v0.3.0">Go SDK</a>.
 {{% /blocks/feature %}}
 
 {{% /blocks/section %}}

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -131,9 +131,6 @@ CDEvents is an incubated project at the <a href="https://cd.foundation/projects"
 	{{< /card >}}
 {{< /cardpane >}}
 
-<p>
-	CDEvents is implemented or being integrated by many of your favorite SDLC tools, including Argo, Flux, Guac, Harbor, Jenkins, Keptn, Spinnaker, Tekton, Testkube, Tracetest and more.
-</p>
 <br/><br/>
 <div class="mx-auto">
 	<a class="btn btn-lg btn-dark mr-3 mb-4" href="docs">
@@ -143,7 +140,7 @@ CDEvents is an incubated project at the <a href="https://cd.foundation/projects"
 {{< /blocks/cdelead >}}
 
 {{< blocks/lead title="CDF" color="light">}}
-CDEvents is implemented or being integrated by many of your favorite SDLC tools, including Argo, Flux, Guac, Harbor, Jenkins, Keptn, Spinnaker, Tekton, Testkube, Tracetest and more.</br></br>
+CDEvents is implemented or being integrated by many of your favorite Software Development Life Cycle (SDLC) tools, including Argo, Flux, Guac, Harbor, Jenkins, Keptn, Spinnaker, Tekton, Testkube, Tracetest and more.</br></br>
 
 <a href="https://www.jenkins.io" aria-label="Jenkins"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/jenkins/stacked/color/jenkins-stacked-color.svg" width="15%" alt="Jenkins Logo"/></a>&nbsp;&nbsp;
 <a href="https://testkube.io" aria-label="testkube"><img src="https://raw.githubusercontent.com/kubeshop/testkube/develop/assets/testkube-color-dark.png" width="20%" alt="Testkube Logo"/></a>

--- a/content/en/community/_index.html
+++ b/content/en/community/_index.html
@@ -46,7 +46,7 @@ weight = 30
 </section>
 {{% cardpane %}}
 {{< blocks/feature title="Are you developing a CI/CD tool?" image_anchor="center" width="50%" height="min" color="dark" >}}
-<h2 class="text-center">The CDEvents SIG needs you!</h2>
+<h2 class="text-center">CDEvents needs you!</h2>
 <p class="lead">We need your help to spread the implementation of CDEvents as an international standard. Get in touch and let us help you extend your product to provide new capabilities for your users.</p>
 <p class="lead">You can find out how to contribute to CDEvents in our <a href="/community/contribution-guidelines/">Contribution Guidelines</a></p>
 {{< /blocks/feature >}}
@@ -54,7 +54,7 @@ weight = 30
 {{< blocks/feature title="Want to shape the standard?" image_anchor="center" width="50%" height="min" color="dark" icon="fa-sharp fa-solid fa-hand-holding-heart">}}
 <h2 class="text-center">You can help to make a difference</h2>
 <p class="lead">We would love you to get involved in defining new events and helping to evolve our specification as we grow to meet the demands of Continuous Delivery.</p>
-<p class="lead">Come along to a CDEvents SIG meeting <a href="https://github.com/cdfoundation/sig-events">How to get involved</a></p>
+<p class="lead">Come along to a <a href="https://github.com/cdevents/community?tab=readme-ov-file#how-to-get-involved">CDEvents meeting</a></p>
 {{< /blocks/feature >}}
 
 {{< blocks/feature title="Enjoy writing and mentoring?" image_anchor="center" width="50%" height="min" color="dark" icon="fa-solid fa-book">}}

--- a/content/en/community/contribution-guidelines.md
+++ b/content/en/community/contribution-guidelines.md
@@ -13,7 +13,12 @@ description: >
 <!-- cSpell:locale en-US -->
 # Contribution Guidelines
 
-Thank you for contributing your time and expertise to CDEvents. This document describes the contribution guidelines for the project.
+Thank you for contributing your time and expertise to CDEvents. This document describes the contribution guidelines for the project specification and website:
+
+* [sdk-go](https://github.com/cdevents/sdk-go?tab=readme-ov-file#contributing)
+* [sdk-java](https://github.com/cdevents/sdk-java?tab=readme-ov-file#contributing)
+
+The CDEvents SDKs have dedicated contributing guides in the respective repositories.
 
 **Note:** Before you start contributing, you must read and abide by our **[Code of Conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md)**.
 
@@ -32,7 +37,7 @@ CDEvents welcomes all of contributions! We encourage you to engage with the
 Resources for contributors:
 
 * [Project Roadmap](/community/roadmap)
-* [Specification v0.2 Roadmap](https://github.com/orgs/cdevents/projects/1/views/9)
+* [Specification v0.4 Roadmap](https://github.com/orgs/cdevents/projects/1/views/13)
 * [GitHub Issues](https://github.com/cdevents/spec/issues)
 * [Communication Channels](https://github.com/cdevents/spec/blob/main/README.md#community)
 
@@ -75,8 +80,9 @@ Install a copy of [Hugo](https://gohugo.io) in your dev environment. You will ne
 From within your local copy of your cdevents.dev fork, start the Hugo server with the following:
 
 ```bash
- netlify dev
+netlify dev
  ```
+
 <!-- markdownlint-disable-next-line MD001 MD034 -->
  This will allow you to browse your copy of the website at http://localhost:8888
 

--- a/content/en/community/contribution-guidelines.md
+++ b/content/en/community/contribution-guidelines.md
@@ -15,10 +15,10 @@ description: >
 
 Thank you for contributing your time and expertise to CDEvents. This document describes the contribution guidelines for the project specification and website:
 
+The CDEvents SDKs have dedicated contributing guides in the respective repositories:
+
 * [sdk-go](https://github.com/cdevents/sdk-go?tab=readme-ov-file#contributing)
 * [sdk-java](https://github.com/cdevents/sdk-java?tab=readme-ov-file#contributing)
-
-The CDEvents SDKs have dedicated contributing guides in the respective repositories.
 
 **Note:** Before you start contributing, you must read and abide by our **[Code of Conduct](https://github.com/cdevents/.github/blob/main/docs/CODE_OF_CONDUCT.md)**.
 

--- a/content/en/community/roadmap.md
+++ b/content/en/community/roadmap.md
@@ -10,10 +10,11 @@ description: >
     Roadmap
 ---
 -->
+
 <!-- cSpell:locale en-US -->
 # CDEvents Mission and Roadmap
 
-This document describes the mission of the CDEvents and its overall roadmap for 2022.
+This document describes the mission of the CDEvents and its overall roadmap for 2023/2024.
 
 ## Mission & Vision
 
@@ -29,18 +30,29 @@ We envision an ecosystem of tools to generate, store, process and visualize CDEv
 
 The continuous delivery ecosystem is quite large as it includes tools and services that span from the design of software, through its implementation, build, test, release, deployment and operation.
 
-In 2022 we want to focus on a few [key use cases](/docs/primer#use-cases) and make sure that we can fully support them with the protocol specification. More specifically:
+In 2023/2024 we want to focus on a few [key use cases](/docs/primer#use-cases) and make sure that we can fully support them with the protocol specification. More specifically:
 
-- Capture our key use cases and design decisions in the [CDEvents primer](/docs/primer) document
-- Develop the spec to fully support our [key use cases](/docs/primer#use-cases)
-  - Create [release v0.2](https://github.com/orgs/cdevents/projects/1/views/8)
-  - Define the specification versioning and stability policy
-  - Define our requirements for a v1.0
-- Validate and demonstrate the spec through proofs-of-concept
-- Specify and rework the CloudEvents binding, and develop SDKS:
-  - Re-create the SDK for the `go` language
-  - Create a new SDK for the `python` language
 - Evolve the project bootstrap governance into a full governance
-- Grow the CDEvents community of projects and contributors
+- On the CDEvents specification
+  - Define a mechanism for linking events with each other
+  - Expand the scope with Ticket and Approval events
+  - Introduce supply chain aspects:
+    - Add SBOM link into artifact events
+    - Add mechanism to track releases
+  - Expand the set of events available to artifact registries
+  - Introduce support for groups of subjects. Examples:
+    - A group of changes that represent a release
+    - A group of artifacts that represent an application
+- On the CDEvents SDK
+  - Complete the work of auto-generating the Java SDK
+  - Make the Python SDK auto-generated from the spec
+  - Develop an SDK in Rust, JavaScript and .NET
+- Release Management
+  - Create [release v0.4](https://github.com/orgs/cdevents/projects/1/views/13)
+  - Define the project release cadence
+  - Define our requirements for a v1.0
+- Publish an updated whitepaper
+- Validate and demonstrate the spec through proofs-of-concept
+- Continue to collaborate with various communities to promote CDEvents adoption
 
 The implementation of proofs of concept will require having CDEvents emitted by various platforms which do not support CDEvents yet. Where possible we will work with the community; it is likely we will have to develop producers and consumers of CDEvents that can adapt existing event formats into CDEvents. We will host such reference implementations in the `cdevents` organization at least until they can find a new home in the target project. These implementations will be useful to identify the mapping between the data model of a specific platform and CDEvents; we can add these mappings to supporting documentation in `cdevents` organization.


### PR DESCRIPTION
- Update out-of-date data on the mainpage
- Add project logos to the mainpage
- Update the contribution guide to include SDKs
- Update the roadmap for 2023/2024, remove achieved items, add new ones
- Update the community page with new links to the community repo