### PR TITLE
Fix the slack link

### DIFF
--- a/content/en/community/_index.html
+++ b/content/en/community/_index.html
@@ -39,7 +39,7 @@ weight = 30
       <a target="_blank" rel="noopener" href="https://github.com/cdevents/spec"><i class="fab fa-github"></i> GitHub:</a> CDEvents Specification on GitHub
     </li>
     <li title="Slack">
-        <a target="_blank" rel="noopener" href="https://cdeliveryfdn.slack.com/archives/C0151BTKEJX"><i class="fab fa-slack"></i> Slack:</a> Chat with us on the CDF Slack
+        <a target="_blank" rel="noopener" href="https://join.slack.com/t/cdeliveryfdn/shared_invite/zt-nwc0jjd0-G65oEpv5ynFfPD5oOX5Ogg"><i class="fab fa-slack"></i> Slack:</a> Chat with us on the CDF Slack (#cdevents channel)
     </li>
 </ul>
 </div>
@@ -60,7 +60,7 @@ weight = 30
 {{< blocks/feature title="Enjoy writing and mentoring?" image_anchor="center" width="50%" height="min" color="dark" icon="fa-solid fa-book">}}
 <h2 class="text-center">Improve our documentation</h2>
 <p class="lead">We always need help to shape and polish our website. Maybe you could also support us by helping to connect with and evangelize to new communities using CI/CD.</p>
-<p class="lead">Join us on Slack and find out what is on the roadmap <a href="https://cdeliveryfdn.slack.com/archives/C0151BTKEJX">Click this invitation</a></p>
+<p class="lead">Join us on Slack and find out what is on the roadmap <a href="https://join.slack.com/t/cdeliveryfdn/shared_invite/zt-nwc0jjd0-G65oEpv5ynFfPD5oOX5Ogg">Click this invitation</a></p>
 {{< /blocks/feature >}}
 {{% /cardpane %}}
 


### PR DESCRIPTION
There are two slack links in the community page, both point to the sig-events channel on the CDF slack. Those links do not work for those who have not joined the CDF slack yet.

Replace the links with a link to the public invite to the slack workspace. Add a comment about the #cdevents channel, which is where CDEvents discussions happen today.

Fixes: #40