### PR TITLE
Publish link schemas

### DIFF
--- a/.github/workflows/nightly-deploy.yaml
+++ b/.github/workflows/nightly-deploy.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: {}
 jobs:
   sync:
-    name: 'Sync content and deploy'
+    name: Sync content and deploy
     runs-on: ubuntu-latest
 
     defaults:
@@ -27,7 +27,7 @@ jobs:
           # Stage changes and check status
           GIT_STATUS=$(git status -s)
           if [ -n "$GIT_STATUS" ]; then PUSH_AND_SYNC='true' ; fi
-          echo ::set-output name=PUSH_AND_SYNC::${PUSH_AND_SYNC}
+          echo "PUSH_AND_SYNC=${PUSH_AND_SYNC}" >> $GITHUB_OUTPUT
 
       - name: Create a commit and push if needed
         if: ${{ steps.update.outputs.PUSH_AND_SYNC }}

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -8,22 +8,27 @@ STATIC_DIR="${BASE_DIR}/static"
 DOCS_DIR="$(mktemp -d)"
 
 # Clone the spec repo to pull the schemas
-git clone https://github.com/cdevents/spec ${DOCS_DIR}
+git clone https://github.com/cdevents/spec "${DOCS_DIR}"
 
 # Serve versioned schemas
 cd "${DOCS_DIR}"
 for tag in $(git tag); do
     # Get the version by trimming the "v"
-    version=$(printf $tag | sed 's/^v//g')
+    version=$(printf '%s' "${tag}" | sed 's/^v//g')
     TARGET_SCHEMA_FOLDER="${STATIC_DIR}/${version}/schema"
     # Create the folder if it doesn't exists yet
-    mkdir -p ${TARGET_SCHEMA_FOLDER} || true
+    mkdir -p "${TARGET_SCHEMA_FOLDER}" || true
 
     git checkout "${tag}"
-    for schema in $(ls schemas/*json); do
+    for schema in schemas/*json; do
         # Extract the schema name from the schema id itself
-        TARGET_SCHEMA=$(awk -F'/' '/"\$id"/{ print $6 }' $schema | sed -e 's/",//g')
+        TARGET_SCHEMA=$(awk -F'/' '/"\$id"/{ print $6 }' "${schema}" | sed -e 's/",//g')
         # Copy the file to static with the new name
-        cp ${schema} ${TARGET_SCHEMA_FOLDER}/${TARGET_SCHEMA}
+        cp "${schema}" "${TARGET_SCHEMA_FOLDER}/${TARGET_SCHEMA}"
     done
+
+    # Starting with v0.4 we serve links schemas too
+    if [[ -d schemas/links ]]; then
+        cp -r schemas/links "${TARGET_SCHEMA_FOLDER}"
+    fi
 done


### PR DESCRIPTION
Starting with v0.4.0 the spec includes links schemas which needs to be published along with the other jsonschemas.

Fixes: #43