### PR TITLE
Add link to CDviz as tool

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -143,7 +143,8 @@ CDEvents is an incubated project at the <a href="https://cd.foundation/projects"
 CDEvents is implemented or being integrated by many of your favorite Software Development Life Cycle (SDLC) tools, including Argo, Flux, Guac, Harbor, Jenkins, Keptn, Spinnaker, Tekton, Testkube, Tracetest and more.</br></br>
 
 <a href="https://www.jenkins.io" aria-label="Jenkins"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/jenkins/stacked/color/jenkins-stacked-color.svg" width="15%" alt="Jenkins Logo"/></a>&nbsp;&nbsp;
-<a href="https://testkube.io" aria-label="testkube"><img src="https://raw.githubusercontent.com/kubeshop/testkube/develop/assets/testkube-color-dark.png" width="20%" alt="Testkube Logo"/></a>
+<a href="https://testkube.io" aria-label="testkube"><img src="https://raw.githubusercontent.com/kubeshop/testkube/develop/assets/testkube-color-dark.png" width="20%" alt="Testkube Logo"/></a>&nbsp;&nbsp;
+<a href="https://cdviz.dev" aria-label="cdviz"><img src="https://cdviz.dev/favicon.svg" width="10%" alt="CDviz Logo"/></a>
 </br></br>
 <a href="https://spinnaker.io" aria-label="Spinnaker"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/spinnaker/stacked/color/spinnaker-stacked-color.svg" width="15%" alt="Spinnaker Logo" class="very-opaque-image"/></a>&nbsp;&nbsp;
 <a href="https://tekton.dev" aria-label="Tekton"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/tekton/stacked/color/tekton-stacked-color.svg" width="15%" alt="Tekton Logo" class="very-opaque-image"/></a>


### PR DESCRIPTION
Add a link to [CDviz](https://cdviz.dev), a set of tools based on CDEvents.