### PR TITLE
Fix source URL of Tekton logo

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -147,7 +147,7 @@ CDEvents is implemented or being integrated by many of your favorite Software De
 <a href="https://cdviz.dev" aria-label="cdviz"><img src="https://cdviz.dev/favicon.svg" width="10%" alt="CDviz Logo"/></a>
 </br></br>
 <a href="https://spinnaker.io" aria-label="Spinnaker"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/spinnaker/stacked/color/spinnaker-stacked-color.svg" width="15%" alt="Spinnaker Logo" class="very-opaque-image"/></a>&nbsp;&nbsp;
-<a href="https://tekton.dev" aria-label="Tekton"><img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/tekton/stacked/color/tekton-stacked-color.svg" width="15%" alt="Tekton Logo" class="very-opaque-image"/></a>
+<a href="https://tekton.dev" aria-label="Tekton"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/tekton/stacked/color/tekton-stacked-color.svg" width="15%" alt="Tekton Logo" class="very-opaque-image"/></a>
 </br></br>
 <a href="https://argoproj.github.io" aria-label="Argo"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/argo/stacked/color/argo-stacked-color.svg" width="10%" alt="Argo Logo" class="slightly-opaque-image"/></a>&nbsp;&nbsp;
 <a href="https://flux.io" aria-label="Flux"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/stacked/color/flux-stacked-color.svg" width="10%" alt="Flux Logo" class="slightly-opaque-image"/></a>&nbsp;&nbsp;


### PR DESCRIPTION
The Tekton logo is not currently displayed correctly on the landing page as the URL it's pointing at is no longer valid.
Update the URL to point to its location in the CNCF artwork repo instead.